### PR TITLE
Ab#374 Fixed service unavailable for bulk award mixed case N/A amount range 

### DIFF
--- a/src/main/java/com/beis/subsidy/award/transperancy/dbpublishingservice/service/AwardService.java
+++ b/src/main/java/com/beis/subsidy/award/transperancy/dbpublishingservice/service/AwardService.java
@@ -111,7 +111,8 @@ public class AwardService {
 
 
 		List<Award> awards = bulkAwards.stream()
-				.map( bulkaward -> new Award(null, getBeneficiaryDetails(bulkaward, beneficiaries), getGrantingAuthority(bulkaward), getSubsidyMeasure(bulkaward), bulkaward.getSubsidyAmountRange(), 
+				.map( bulkaward -> new Award(null, getBeneficiaryDetails(bulkaward, beneficiaries), getGrantingAuthority(bulkaward), getSubsidyMeasure(bulkaward),
+						bulkaward.getSubsidyAmountRange() != null ? bulkaward.getSubsidyAmountRange().toUpperCase() : "N/A",
 						( (bulkaward.getSubsidyAmountExact() != null) ? new BigDecimal(bulkaward.getSubsidyAmountExact()) : BigDecimal.ZERO),  
 						((bulkaward.getSubsidyObjective().equalsIgnoreCase("Other"))? "Other - "+bulkaward.getSubsidyObjectiveOther():bulkaward.getSubsidyObjective()), bulkaward.getGoodsOrServices(),
 						convertToDate(bulkaward.getLegalGrantingDate()),
@@ -234,7 +235,8 @@ public class AwardService {
 			AdminProgram adminProgram = adminProgramRepository.findById(award.getAdminProgramNumber()).orElse(null);
 
 			Award saveAward = new Award(null, beneficiary, getGrantingAuthority(tempAward),
-					getSubsidyMeasure(tempAward), award.getSubsidyAmountRange(),
+					getSubsidyMeasure(tempAward),
+					award.getSubsidyAmountRange() != null ? award.getSubsidyAmountRange().toUpperCase() : "N/A",
 					((award.getSubsidyAmountExact() != null) ? new BigDecimal(award.getSubsidyAmountExact())
 							: BigDecimal.ZERO),
 					((award.getSubsidyObjective().equalsIgnoreCase("Other")) ? "Other - "+award.getSubsidyObjectiveOther()
@@ -281,7 +283,7 @@ public class AwardService {
 				award.setSubsidyFullAmountExact(new BigDecimal(awardUpdateRequest.getSubsidyAmountExact()));
 			}
 			if (!StringUtils.isEmpty(awardUpdateRequest.getSubsidyAmountRange())) {
-				award.setSubsidyFullAmountRange(awardUpdateRequest.getSubsidyAmountRange());
+				award.setSubsidyFullAmountRange(awardUpdateRequest.getSubsidyAmountRange().toUpperCase());
 			}
 			if (!StringUtils.isEmpty(awardUpdateRequest.getSpendingRegion())) {
 				award.setSpendingRegion(awardUpdateRequest.getSpendingRegion());

--- a/src/main/java/com/beis/subsidy/award/transperancy/dbpublishingservice/service/BulkUploadAwardsService.java
+++ b/src/main/java/com/beis/subsidy/award/transperancy/dbpublishingservice/service/BulkUploadAwardsService.java
@@ -538,7 +538,7 @@ public class BulkUploadAwardsService {
 		if(!SubsidyFullAmountInapplicableErrorList.isEmpty()) {
 			validationSubsidyAmountExactErrorResultList = SubsidyFullAmountInapplicableErrorList.stream()
 					.map(award -> new ValidationErrorResult(String.valueOf(award.getRow()), columnMapping.get("Full Exact"),
-							"Subsidy Element Full Amount field is only applicable to non-tax measure subsidies. Remove the amount value or change subsidy type."))
+							"Subsidy Element Full Amount field is only applicable to non-tax measure subsidy instruments. Remove the amount value or change the subsidy instrument."))
 					.collect(Collectors.toList());
 		}
 
@@ -604,12 +604,16 @@ public class BulkUploadAwardsService {
 		List<ValidationErrorResult> validationTaxRangeAmountErrorResultList = new ArrayList<>();
 
 		List<BulkUploadAwards> SubsidyTaxRangeInapplicableErrorList = bulkUploadAwards.stream()
-				.filter(award -> (!award.getSubsidyInstrument().startsWith("Tax") && !(award.getSubsidyAmountRange() == null || StringUtils.isEmpty(award.getSubsidyAmountRange())))).collect(Collectors.toList());
+				.filter(award -> (!award.getSubsidyInstrument().startsWith("Tax")
+						&& !(award.getSubsidyAmountRange() == null
+						|| StringUtils.isEmpty(award.getSubsidyAmountRange())
+						|| StringUtils.contains(award.getSubsidyAmountRange().toUpperCase(), "N/A")))
+				).collect(Collectors.toList());
 
 		if(!SubsidyTaxRangeInapplicableErrorList.isEmpty()) {
 			validationTaxRangeAmountErrorResultList = SubsidyTaxRangeInapplicableErrorList.stream()
 					.map(award -> new ValidationErrorResult(String.valueOf(award.getRow()), columnMapping.get("Full Range"),
-							"Subsidy Full Amount Range is only applicable to tax measure subsidies. Remove the range value or change subsidy type."))
+							"Subsidy Full Amount Range is only applicable to tax measure subsidy instruments. Remove the range value or change the subsidy instrument."))
 					.collect(Collectors.toList());
 		}
 


### PR DESCRIPTION
Bulk award amount ranges are now made upper case to avoid mixed case entries in the db causing service unavailable

Refactored error messages and allowed N/A values for amount range in the bulk upload award template