### PR TITLE
AB#318 Allowed short format for MFA award confirmation date

### DIFF
--- a/src/main/java/com/beis/subsidy/award/transperancy/dbpublishingservice/service/MFAService.java
+++ b/src/main/java/com/beis/subsidy/award/transperancy/dbpublishingservice/service/MFAService.java
@@ -29,7 +29,6 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.*;
 
 @Slf4j


### PR DESCRIPTION
Added try catch when converting date string to LocalDate to allow short dates to be used without causing an error

Added log.error message for when the date input is an invalid format